### PR TITLE
Usage for no options added and readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiveData Migrator Diagnostics UI
 
-Script will parse LiveData Migrator diagnostic logs and 
+Script will parse LiveData Migrator diagnostic logs and
 talkbacks and create a UI.
 
 ```
@@ -38,13 +38,13 @@ python3 diagnostics-ui.py --ingest diag-set-1 --serve talkback-LIVEDATA_MIGRATOR
 To process a talkback and start web server, diagnostic set will be identified as talkback-LIVEDATA_MIGRATOR-20230509113117-diag.wandisco.com as --ingress is not set
 
 ```
-python3 diagnostics-ui.py --serve --tarball talkback-LIVEDATA_MIGRATOR-20230509113117-diag.wandisco.com.tar.gz 
+python3 diagnostics-ui.py --serve --tarball talkback-LIVEDATA_MIGRATOR-20230509113117-diag.wandisco.com.tar.gz
 ```
 
 To start the web server and server existing data sets:
 
 ```
-python3 diagnostics-ui.py
+python3 diagnostics-ui.py --serve
 ```
 
 By default directory used to store files is python.workspace in the current working directory.

--- a/diagnostics-ui.py
+++ b/diagnostics-ui.py
@@ -1327,6 +1327,11 @@ def main():
     parser.add_argument("files", nargs="*")
     args = parser.parse_args()
 
+    # if no args print README and exit
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     # First do some args sanity.
     process_args(args)
 


### PR DESCRIPTION
README file changed to include --serve in command line for starting the web server and server existing data sets.

If no options are passed code will exit and help will be displayed.